### PR TITLE
[翻訳] OpenSearch 3.0 における JSM の代替手段

### DIFF
--- a/articles/opensearch-jsm-replacement-3-0.md
+++ b/articles/opensearch-jsm-replacement-3-0.md
@@ -4,7 +4,7 @@ emoji: "🔐"
 type: "tech"
 topics: ["opensearch", "java", "security"]
 publication_name: "opensearch"
-published: false
+published: true
 published_at: 2025-06-03
 ---
 


### PR DESCRIPTION
## 概要
OpenSearch ブログ記事の日本語翻訳です。

## 原文
https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/

## 関連 Issue
Closes #96