### PR TITLE
Add session issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/session.yml
+++ b/.github/ISSUE_TEMPLATE/session.yml
@@ -1,0 +1,25 @@
+name: Session Article Request
+description: Request article creation from OpenSearchCon session video
+title: "[Session] "
+labels: ["session"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Session Video
+  - type: input
+    id: youtube_url
+    attributes:
+      label: YouTube URL
+      description: URL of the session video
+      placeholder: https://www.youtube.com/watch?v=...
+    validations:
+      required: true
+  - type: input
+    id: slug
+    attributes:
+      label: Slug
+      description: Article slug (e.g., opensearchcon-kr-2025-session-title)
+      placeholder: opensearchcon-kr-2025-...
+    validations:
+      required: true


### PR DESCRIPTION
OpenSearchCon セッション動画の記事作成リクエスト用 Issue テンプレートを追加します。

- YouTube URL と slug を入力するフォーム
- `session` ラベルが自動付与